### PR TITLE
Update attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Each element in the list has the following attributes:
  * `text: str`: language specific additional information about the warning
  * `starts_at: datetime`: time at which the warning starts being relevant
  * `ends_at: datetime`: time at which the warning stops being relevant
+ * `is_active: bool`: `true` if `starts_at` < now < `ends_at`
 
 The following table summarizes the different known warning types.  Other warning types may be returned and will have `unknown` as slug.  Feel free to open an issue with the id and the English friendly name to have it added to this integration.
 
@@ -103,6 +104,9 @@ The following table summarizes the different known warning types.  Other warning
 | thunderstorm_large_rainfall | 14         | Thunderstorm & large rainfall, Orage et averses, Onweer en regen, Gewitter und Regen     |
 | storm_surge                 | 15         | Storm surge, Marée forte, Stormtij, Sturmflut                                            |
 | coldspell                   | 17         | Coldspell, Vague de froid, Koude, Koude                                                  |
+
+The sensor has an attribute called `active_warnings_friendly_names`, holding a comma separated list of the friendly names
+of the currently active warnings (e.g. `Fog, Ice or snow`).  There is no particular order for the list.
 
 ## Disclaimer
 

--- a/custom_components/irm_kmi/binary_sensor.py
+++ b/custom_components/irm_kmi/binary_sensor.py
@@ -59,4 +59,12 @@ class IrmKmiWarning(CoordinatorEntity, BinarySensorEntity):
     def extra_state_attributes(self) -> dict:
         """Return the camera state attributes."""
         attrs = {"warnings": self.coordinator.data.get('warnings', [])}
+
+        now = datetime.datetime.now(tz=pytz.timezone(self.hass.config.time_zone))
+        for warning in attrs['warnings']:
+            warning['is_active'] = warning.get('starts_at') < now < warning.get('ends_at')
+
+        attrs["active_warnings_friendly_names"] = ", ".join([warning['friendly_name'] for warning in attrs['warnings']
+                                                             if warning['is_active']])
+
         return attrs

--- a/custom_components/irm_kmi/coordinator.py
+++ b/custom_components/irm_kmi/coordinator.py
@@ -130,7 +130,7 @@ class IrmKmiCoordinator(DataUpdateCoordinator):
         """From the API data, create the object that will be used in the entities"""
         return ProcessedCoordinatorData(
             current_weather=IrmKmiCoordinator.current_weather_from_data(api_data),
-            daily_forecast=IrmKmiCoordinator.daily_list_to_forecast(api_data.get('for', {}).get('daily')),
+            daily_forecast=self.daily_list_to_forecast(api_data.get('for', {}).get('daily')),
             hourly_forecast=IrmKmiCoordinator.hourly_list_to_forecast(api_data.get('for', {}).get('hourly')),
             animation=await self._async_animation_data(api_data=api_data),
             warnings=self.warnings_from_data(api_data.get('for', {}).get('warning'))
@@ -257,8 +257,7 @@ class IrmKmiCoordinator(DataUpdateCoordinator):
 
         return forecasts
 
-    @staticmethod
-    def daily_list_to_forecast(data: List[dict] | None) -> List[Forecast] | None:
+    def daily_list_to_forecast(self, data: List[dict] | None) -> List[Forecast] | None:
         """Parse data from the API to create a list of daily forecasts"""
         if data is None or not isinstance(data, list) or len(data) == 0:
             return None
@@ -295,8 +294,7 @@ class IrmKmiCoordinator(DataUpdateCoordinator):
                 precipitation_probability=f.get('precipChance', None),
                 wind_bearing=f.get('wind', {}).get('dirText', {}).get('en'),
                 is_daytime=is_daytime,
-                text_fr=f.get('text', {}).get('fr'),
-                text_nl=f.get('text', {}).get('nl')
+                text=f.get('text', {}).get(self.hass.config.language, ""),
             )
             forecasts.append(forecast)
             if is_daytime or idx == 0:

--- a/custom_components/irm_kmi/coordinator.py
+++ b/custom_components/irm_kmi/coordinator.py
@@ -71,7 +71,6 @@ class IrmKmiCoordinator(DataUpdateCoordinator):
             raise UpdateFailed(f"Error communicating with API: {err}")
 
         if api_data.get('cityName', None) in OUT_OF_BENELUX:
-            # TODO create a repair when this triggers
             _LOGGER.info(f"Config state: {self._config_entry.state}")
             _LOGGER.error(f"The zone {self._zone} is now out of Benelux and forecast is only available in Benelux."
                           f"Associated device is now disabled.  Move the zone back in Benelux and re-enable to fix "

--- a/custom_components/irm_kmi/coordinator.py
+++ b/custom_components/irm_kmi/coordinator.py
@@ -347,10 +347,10 @@ class IrmKmiCoordinator(DataUpdateCoordinator):
                          dark_mode=self._dark_mode,
                          tz=self.hass.config.time_zone)
 
-    def warnings_from_data(self, warning_data: list | None) -> List[WarningData] | None:
+    def warnings_from_data(self, warning_data: list | None) -> List[WarningData]:
         """Create a list of warning data instances based on the api data"""
         if warning_data is None or not isinstance(warning_data, list) or len(warning_data) == 0:
-            return None
+            return []
 
         result = list()
         for data in warning_data:
@@ -379,4 +379,4 @@ class IrmKmiCoordinator(DataUpdateCoordinator):
                 )
             )
 
-        return result if len(result) > 0 else None
+        return result if len(result) > 0 else []

--- a/custom_components/irm_kmi/data.py
+++ b/custom_components/irm_kmi/data.py
@@ -9,9 +9,7 @@ class IrmKmiForecast(Forecast):
     """Forecast class with additional attributes for IRM KMI"""
 
     # TODO: add condition_2 as well and evolution to match data from the API?
-    # TODO: remove the _fr and _nl to have only one 'text' attribute
-    text_fr: str | None
-    text_nl: str | None
+    text: str | None
 
 
 class CurrentWeatherData(TypedDict, total=False):

--- a/custom_components/irm_kmi/data.py
+++ b/custom_components/irm_kmi/data.py
@@ -63,4 +63,4 @@ class ProcessedCoordinatorData(TypedDict, total=False):
     hourly_forecast: List[Forecast] | None
     daily_forecast: List[IrmKmiForecast] | None
     animation: RadarAnimationData
-    warnings: List[WarningData] | None
+    warnings: List[WarningData]

--- a/tests/fixtures/forecast.json
+++ b/tests/fixtures/forecast.json
@@ -66,7 +66,8 @@
 				"dayNight": "d",
 				"text": {
 					"nl": "Foo",
-					"fr": "Bar"
+					"fr": "Bar",
+					"en": "Hey!"
 				},
 				"dawnRiseSeconds": "31440",
 				"dawnSetSeconds": "60180",

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -25,3 +25,8 @@ async def test_warning_data(
 
     assert warning.is_on
     assert len(warning.extra_state_attributes['warnings']) == 2
+
+    for w in warning.extra_state_attributes['warnings']:
+        assert w['is_active']
+
+    assert warning.extra_state_attributes['active_warnings_friendly_names'] == "Fog, Ice or snow"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -82,9 +82,14 @@ def test_current_weather_nl() -> None:
 
 
 @freeze_time(datetime.fromisoformat('2023-12-26T18:30:00.028724'))
-def test_daily_forecast() -> None:
+async def test_daily_forecast(
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry
+) -> None:
     api_data = get_api_data("forecast.json").get('for', {}).get('daily')
-    result = IrmKmiCoordinator.daily_list_to_forecast(api_data)
+
+    coordinator = IrmKmiCoordinator(hass, mock_config_entry)
+    result = coordinator.daily_list_to_forecast(api_data)
 
     assert isinstance(result, list)
     assert len(result) == 8
@@ -100,8 +105,7 @@ def test_daily_forecast() -> None:
         precipitation_probability=0,
         wind_bearing='S',
         is_daytime=True,
-        text_fr='Bar',
-        text_nl='Foo'
+        text='Hey!',
     )
 
     assert result[1] == expected


### PR DESCRIPTION
* Forecast data: remove `text_fr` and `text_nl`, add `text`.  The new `text` attribute fetches the description in the language of the instance.  Defaults to the empty string when language is not available from the API data
* Warning binary sensor: add `active_warnings_friendly_names`, a comma separated list of friendly names of the active warnings
* Warning binary sensor: for each warning add a boolean attribute `is_active` to tell if the warning is currently relevant (i.e. start time < now < end time)