### PR TITLE
Improve handling of API errors such as timeout

### DIFF
--- a/custom_components/irm_kmi/api.py
+++ b/custom_components/irm_kmi/api.py
@@ -71,7 +71,7 @@ class IrmKmiApiClient:
         """Get information from the API."""
 
         try:
-            async with async_timeout.timeout(10):
+            async with async_timeout.timeout(60):
                 response = await self._session.request(
                     method=method,
                     url=f"{self._base_url if base_url is None else base_url}{path}",

--- a/custom_components/irm_kmi/coordinator.py
+++ b/custom_components/irm_kmi/coordinator.py
@@ -187,7 +187,7 @@ class IrmKmiCoordinator(TimestampDataUpdateCoordinator):
             if frame.get('uri', None) is not None:
                 coroutines.append(
                     self._api_client.get_image(frame.get('uri'), params={'rs': STYLE_TO_PARAM_MAP[self._style]}))
-        async with async_timeout.timeout(20):
+        async with async_timeout.timeout(60):
             images_from_api = await asyncio.gather(*coroutines)
 
         _LOGGER.debug(f"Just downloaded {len(images_from_api)} images")

--- a/custom_components/irm_kmi/coordinator.py
+++ b/custom_components/irm_kmi/coordinator.py
@@ -116,10 +116,8 @@ class IrmKmiCoordinator(DataUpdateCoordinator):
         try:
             images_from_api = await self.download_images_from_api(animation_data, country, localisation_layer_url)
         except IrmKmiApiError as err:
-            _LOGGER.warning(f"Could not get images for weather radar: {err}")
-            # TODO idea return self.data.get('animation', RadarAnimationData())
-            #  this way, when we cannot update, we keep the old data
-            return RadarAnimationData()
+            _LOGGER.warning(f"Could not get images for weather radar: {err}.  Keep the existing radar data.")
+            return self.data.get('animation', RadarAnimationData()) if self.data is not None else RadarAnimationData()
 
         localisation = images_from_api[0]
         images_from_api = images_from_api[1:]
@@ -152,8 +150,9 @@ class IrmKmiCoordinator(DataUpdateCoordinator):
             _LOGGER.debug(f"Requesting pollen SVG at url {svg_url}")
             pollen_svg: str = await self._api_client.get_svg(svg_url)
         except IrmKmiApiError as err:
-            _LOGGER.warning(f"Could not get pollen data from the API: {err}")
-            return PollenParser.get_default_data()
+            _LOGGER.warning(f"Could not get pollen data from the API: {err}. Keeping the same data.")
+            return self.data.get('pollen', PollenParser.get_unavailable_data()) \
+                if self.data is not None else PollenParser.get_unavailable_data()
 
         return PollenParser(pollen_svg).get_pollen_data()
 

--- a/custom_components/irm_kmi/pollen.py
+++ b/custom_components/irm_kmi/pollen.py
@@ -8,6 +8,11 @@ from custom_components.irm_kmi.const import POLLEN_NAMES
 _LOGGER = logging.getLogger(__name__)
 
 
+def get_unavailable_data() -> dict:
+    """Return all the known pollen with 'none' value"""
+    return {k.lower(): 'none' for k in POLLEN_NAMES}
+
+
 class PollenParser:
     """
     The SVG looks as follows (see test fixture for a real example)
@@ -25,6 +30,7 @@ class PollenParser:
     For the color scale, look for a white dot (nearly) at the same level as the pollen name.  From the white dot
     horizontal position, determine the level
     """
+
     def __init__(
             self,
             xml_string: str
@@ -52,6 +58,11 @@ class PollenParser:
     def get_default_data() -> dict:
         """Return all the known pollen with 'none' value"""
         return {k.lower(): 'none' for k in POLLEN_NAMES}
+
+    @staticmethod
+    def get_unavailable_data() -> dict:
+        """Return all the known pollen with 'none' value"""
+        return {k.lower(): None for k in POLLEN_NAMES}
 
     @staticmethod
     def get_option_values() -> List[str]:
@@ -128,4 +139,3 @@ class PollenParser:
 
         _LOGGER.debug(f"Pollen data: {pollen_data}")
         return pollen_data
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,3 +262,20 @@ def mock_coordinator(request: pytest.FixtureRequest) -> Generator[None, MagicMoc
         coord = coordinator_mock.return_value
         coord._async_animation_data.return_value = {'animation': None}
         yield coord
+
+
+@pytest.fixture()
+def mock_irm_kmi_api_works_but_pollen_and_radar_fail(request: pytest.FixtureRequest) -> Generator[
+    None, MagicMock, None]:
+    """Return a mocked IrmKmi api client."""
+    fixture: str = "forecast.json"
+
+    forecast = json.loads(load_fixture(fixture))
+    with patch(
+            "custom_components.irm_kmi.coordinator.IrmKmiApiClient", autospec=True
+    ) as irm_kmi_api_mock:
+        irm_kmi = irm_kmi_api_mock.return_value
+        irm_kmi.get_forecasts_coord.return_value = forecast
+        irm_kmi.get_svg.side_effect = IrmKmiApiError
+        irm_kmi.get_image.side_effect = IrmKmiApiError
+        yield irm_kmi

--- a/tests/test_pollen.py
+++ b/tests/test_pollen.py
@@ -27,6 +27,7 @@ def test_svg_pollen_parsing():
     assert data == {'birch': 'none', 'oak': 'active', 'hazel': 'none', 'mugwort': 'none', 'alder': 'active',
                     'grasses': 'none', 'ash': 'active'}
 
+
 def test_pollen_options():
     assert PollenParser.get_option_values() == ['active', 'green', 'yellow', 'orange', 'red', 'purple', 'none']
 
@@ -50,7 +51,7 @@ async def test_pollen_data_from_api(
     assert result == expected
 
 
-async def test_pollen_error_leads_to_default_values(
+async def test_pollen_error_leads_to_unavailable_on_first_call(
         hass: HomeAssistant,
         mock_config_entry: MockConfigEntry,
         mock_exception_irm_kmi_api_svg_pollen: AsyncMock
@@ -59,5 +60,5 @@ async def test_pollen_error_leads_to_default_values(
     api_data = get_api_data("be_forecast_warning.json")
 
     result = await coordinator._async_pollen_data(api_data)
-    expected = PollenParser.get_default_data()
+    expected = PollenParser.get_unavailable_data()
     assert result == expected


### PR DESCRIPTION
- [x] Increase default timeout to 60 seconds (instead of 10)
- [x] Keep radar and pollen data from previous polling if they fail (but the forecast was successfully updated)
- [x] Keep forecast for 3 times the refresh interval before becoming unavailable
- [x] Try to create tests for those features