### PR TITLE
Reduce bandwidth consumption of the integration

### DIFF
--- a/custom_components/irm_kmi/api.py
+++ b/custom_components/irm_kmi/api.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import json
 import logging
 import socket
+import time
 from datetime import datetime
 
 import aiohttp
 import async_timeout
-from aiohttp import ClientResponse
 from .const import USER_AGENT
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,6 +36,8 @@ def _api_key(method_name: str) -> str:
 class IrmKmiApiClient:
     """API client for IRM KMI weather data"""
     COORD_DECIMALS = 6
+    cache_max_age = 60 * 60 * 2  # Remove items from the cache if they have not been hit since 2 hours
+    cache = {}
 
     def __init__(self, session: aiohttp.ClientSession) -> None:
         self._session = session
@@ -47,18 +50,18 @@ class IrmKmiApiClient:
         coord['lat'] = round(coord['lat'], self.COORD_DECIMALS)
         coord['long'] = round(coord['long'], self.COORD_DECIMALS)
 
-        response = await self._api_wrapper(params={"s": "getForecasts", "k": _api_key("getForecasts")} | coord)
-        return await response.json()
+        response: bytes = await self._api_wrapper(params={"s": "getForecasts", "k": _api_key("getForecasts")} | coord)
+        return json.loads(response)
 
     async def get_image(self, url, params: dict | None = None) -> bytes:
         """Get the image at the specified url with the parameters"""
-        r: ClientResponse = await self._api_wrapper(base_url=url, params={} if params is None else params)
-        return await r.read()
+        r: bytes = await self._api_wrapper(base_url=url, params={} if params is None else params)
+        return r
 
     async def get_svg(self, url, params: dict | None = None) -> str:
         """Get SVG as str at the specified url with the parameters"""
-        r: ClientResponse = await self._api_wrapper(base_url=url, params={} if params is None else params)
-        return await r.text()
+        r: bytes = await self._api_wrapper(base_url=url, params={} if params is None else params)
+        return r.decode()
 
     async def _api_wrapper(
             self,
@@ -68,24 +71,41 @@ class IrmKmiApiClient:
             method: str = "get",
             data: dict | None = None,
             headers: dict | None = None,
-    ) -> any:
+    ) -> bytes:
         """Get information from the API."""
+        url = f"{self._base_url if base_url is None else base_url}{path}"
+
         if headers is None:
             headers = {'User-Agent': USER_AGENT}
         else:
             headers['User-Agent'] = USER_AGENT
 
+        if url in self.cache:
+            headers['If-None-Match'] = self.cache[url]['etag']
+
         try:
             async with async_timeout.timeout(60):
                 response = await self._session.request(
                     method=method,
-                    url=f"{self._base_url if base_url is None else base_url}{path}",
+                    url=url,
                     headers=headers,
                     json=data,
                     params=params
                 )
                 response.raise_for_status()
-                return response
+
+                if response.status == 304:
+                    _LOGGER.debug(f"Cache hit for {url}")
+                    self.cache[url]['timestamp'] = time.time()
+                    return self.cache[url]['response']
+
+                if 'ETag' in response.headers:
+                    _LOGGER.debug(f"Saving in cache {url}")
+                    r = await response.read()
+                    self.cache[url] = {'etag': response.headers['ETag'], 'response': r, 'timestamp': time.time()}
+                    return r
+
+                return await response.read()
 
         except asyncio.TimeoutError as exception:
             raise IrmKmiApiCommunicationError("Timeout error fetching information") from exception
@@ -93,3 +113,13 @@ class IrmKmiApiClient:
             raise IrmKmiApiCommunicationError("Error fetching information") from exception
         except Exception as exception:  # pylint: disable=broad-except
             raise IrmKmiApiError(f"Something really wrong happened! {exception}") from exception
+
+    def expire_cache(self):
+        now = time.time()
+        keys_to_delete = set()
+        for key, value in self.cache.items():
+            if now - value['timestamp'] > self.cache_max_age:
+                keys_to_delete.add(key)
+        for key in keys_to_delete:
+            del self.cache[key]
+        _LOGGER.info(f"Expired {len(keys_to_delete)} elements from API cache")

--- a/custom_components/irm_kmi/data.py
+++ b/custom_components/irm_kmi/data.py
@@ -4,6 +4,8 @@ from typing import List, TypedDict
 
 from homeassistant.components.weather import Forecast
 
+from .rain_graph import RainGraph
+
 
 class IrmKmiForecast(Forecast):
     """Forecast class with additional attributes for IRM KMI"""
@@ -12,13 +14,6 @@ class IrmKmiForecast(Forecast):
     text: str | None
     sunrise: str | None
     sunset: str | None
-
-
-class IrmKmiRadarForecast(Forecast):
-    """Forecast class to handle rain forecast from the IRM KMI rain radar"""
-    rain_forecast_max: float
-    rain_forecast_min: float
-    might_rain: bool
 
 
 class CurrentWeatherData(TypedDict, total=False):
@@ -30,27 +25,6 @@ class CurrentWeatherData(TypedDict, total=False):
     wind_bearing: float | str | None
     uv_index: float | None
     pressure: float | None
-
-
-class AnimationFrameData(TypedDict, total=False):
-    """Holds one single frame of the radar camera, along with the timestamp of the frame"""
-    time: datetime | None
-    image: bytes | None
-    value: float | None
-    position: float | None
-    position_higher: float | None
-    position_lower: float | None
-
-
-class RadarAnimationData(TypedDict, total=False):
-    """Holds frames and additional data for the animation to be rendered"""
-    sequence: List[AnimationFrameData] | None
-    most_recent_image_idx: int | None
-    hint: str | None
-    unit: str | None
-    location: bytes | None
-    svg_still: bytes | None
-    svg_animated: bytes | None
 
 
 class WarningData(TypedDict, total=False):
@@ -70,7 +44,7 @@ class ProcessedCoordinatorData(TypedDict, total=False):
     hourly_forecast: List[Forecast] | None
     daily_forecast: List[IrmKmiForecast] | None
     radar_forecast: List[Forecast] | None
-    animation: RadarAnimationData
+    animation: RainGraph | None
     warnings: List[WarningData]
     pollen: dict
     country: str

--- a/custom_components/irm_kmi/radar_data.py
+++ b/custom_components/irm_kmi/radar_data.py
@@ -1,0 +1,34 @@
+"""Data classes related to radar forecast for IRM KMI integration"""
+# This file was needed to avoid circular import with rain_graph.py and data.py
+from datetime import datetime
+from typing import TypedDict, List
+
+from homeassistant.components.weather import Forecast
+
+
+class IrmKmiRadarForecast(Forecast):
+    """Forecast class to handle rain forecast from the IRM KMI rain radar"""
+    rain_forecast_max: float
+    rain_forecast_min: float
+    might_rain: bool
+
+
+class AnimationFrameData(TypedDict, total=False):
+    """Holds one single frame of the radar camera, along with the timestamp of the frame"""
+    time: datetime | None
+    image: bytes | str | None
+    value: float | None
+    position: float | None
+    position_higher: float | None
+    position_lower: float | None
+
+
+class RadarAnimationData(TypedDict, total=False):
+    """Holds frames and additional data for the animation to be rendered"""
+    sequence: List[AnimationFrameData] | None
+    most_recent_image_idx: int | None
+    hint: str | None
+    unit: str | None
+    location: bytes | str | None
+    svg_still: bytes | None
+    svg_animated: bytes | None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -11,10 +11,10 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.irm_kmi.const import CONF_LANGUAGE_OVERRIDE
 from custom_components.irm_kmi.coordinator import IrmKmiCoordinator
 from custom_components.irm_kmi.data import (CurrentWeatherData, IrmKmiForecast,
-                                            IrmKmiRadarForecast,
-                                            ProcessedCoordinatorData,
-                                            RadarAnimationData)
+                                            ProcessedCoordinatorData)
+from custom_components.irm_kmi.radar_data import IrmKmiRadarForecast, RadarAnimationData
 from custom_components.irm_kmi.pollen import PollenParser
+from custom_components.irm_kmi.rain_graph import RainGraph
 from tests.conftest import get_api_data
 
 
@@ -230,7 +230,7 @@ async def test_refresh_succeed_even_when_pollen_and_radar_fail(
         0,
         {"latitude": 50.738681639, "longitude": 4.054077148},
     )
-
+    hass.config.config_dir = "."
     mock_config_entry.add_to_hass(hass)
 
     coordinator = IrmKmiCoordinator(hass, mock_config_entry)
@@ -239,7 +239,7 @@ async def test_refresh_succeed_even_when_pollen_and_radar_fail(
 
     assert result.get('current_weather').get('condition') == ATTR_CONDITION_CLOUDY
 
-    assert result.get('animation') == dict()
+    assert result.get('animation').get_hint() == "No rain forecasted shortly"
 
     assert result.get('pollen') == PollenParser.get_unavailable_data()
 
@@ -247,7 +247,7 @@ async def test_refresh_succeed_even_when_pollen_and_radar_fail(
         current_weather=CurrentWeatherData(),
         daily_forecast=[],
         hourly_forecast=[],
-        animation=RadarAnimationData(hint="This will remain unchanged"),
+        animation=None,
         warnings=[],
         pollen={'foo': 'bar'}
     )
@@ -256,7 +256,7 @@ async def test_refresh_succeed_even_when_pollen_and_radar_fail(
 
     assert result.get('current_weather').get('condition') == ATTR_CONDITION_CLOUDY
 
-    assert result.get('animation').get('hint') == "This will remain unchanged"
+    assert result.get('animation').get_hint() == "No rain forecasted shortly"
 
     assert result.get('pollen') == {'foo': 'bar'}
 

--- a/tests/test_rain_graph.py
+++ b/tests/test_rain_graph.py
@@ -1,8 +1,7 @@
 import base64
 from datetime import datetime, timedelta
 
-from custom_components.irm_kmi.data import (AnimationFrameData,
-                                            RadarAnimationData)
+from custom_components.irm_kmi.radar_data import AnimationFrameData, RadarAnimationData
 from custom_components.irm_kmi.rain_graph import RainGraph
 
 
@@ -249,7 +248,7 @@ def test_draw_cloud_layer():
     assert str_svg.count('width="640"') == 11  # Is also the width of the SVG itself
 
 
-def test_draw_location_layer():
+async def test_draw_location_layer():
     data = get_radar_animation_data()
     rain_graph = RainGraph(
         animation_data=data,
@@ -257,7 +256,7 @@ def test_draw_location_layer():
         background_size=(640, 490),
     )
 
-    rain_graph.draw_location()
+    await rain_graph.draw_location()
 
     str_svg = rain_graph.get_dwg().tostring()
 

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -10,8 +10,8 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.irm_kmi import IrmKmiCoordinator, IrmKmiWeather
-from custom_components.irm_kmi.data import (IrmKmiRadarForecast,
-                                            ProcessedCoordinatorData)
+from custom_components.irm_kmi.data import (ProcessedCoordinatorData)
+from custom_components.irm_kmi.radar_data import IrmKmiRadarForecast
 from tests.conftest import get_api_data
 
 


### PR DESCRIPTION
Until now, the integration would download all the data (forecast, radar images, pollen) every 7 minutes without client caching.  This pull request brings the following improvements:

- Only download current radar frame and localization layer when the user brings the radar in the viewport
- Download the full sequence of images only if the user shows the animation
- Locally cache the responses and re-use cached data based on the ETag value set the by remote server

The data is still refreshed every 7 minutes with local caching when responses come with the ETag header.  Only the radar animation is downloaded on-demand.  Short-term rain forecast shown on the radar is still downloaded every 7 minutes (this is part of the forecast file anyway).
